### PR TITLE
Improve tutorial template and allow multiple libs

### DIFF
--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -5,35 +5,39 @@
     </h2>
 
     <p>
-      First published: $published$
+      First published: $published$<br/>
+      by $author-name$
     </p>
 
     <p>
       Tested with:
       <ul>
         $if(lts)$
-          <li>
-            Resolver:
-            <a href="https://www.stackage.org/lts-$lts$">
-              LTS Haskell $lts$ (ghc-$ghc$)
-            </a>
-          </li>
+        <li>
+          Resolver:
+          <a href="https://www.stackage.org/lts-$lts$">
+            LTS Haskell $lts$ (ghc-$ghc$)
+          </a>
+        </li>
         $endif$
         $if(nightly)$
-          <li>
-            Resolver:
-            <a href="http://www.stackage.org/nightly-$nightly$">
-              Stackage Nightly $nightly$ (ghc-$ghc$)
-            </a>
-          </li>
+        <li>
+          Resolver:
+          <a href="http://www.stackage.org/nightly-$nightly$">
+            Stackage Nightly $nightly$ (ghc-$ghc$)
+          </a>
+        </li>
         $endif$
-	$if(library)$
-	<li>
-	  <a href="https://hackage.haskell.org/package/$library$">
-	    $library$
-	  </a>
-	</li>
-	$endif$
+        $if(libs)$
+        <li>
+          Libraries:
+          $for(libs)$
+          <a href="https://hackage.haskell.org/package/$lib$">
+            $lib$
+          </a>
+          $endfor$
+        </li>
+        $endif$
       </ul>
     </p>
 

--- a/tutorials/haskell/csv-encoding-decoding/tutorial.md
+++ b/tutorials/haskell/csv-encoding-decoding/tutorial.md
@@ -3,7 +3,7 @@ title: CSV encoding and decoding in Haskell with Cassava
 published: 2016-05-17
 ghc: 7.10.3
 lts: 5.15
-library: cassava-0.4.5.0
+libraries: cassava-0.4.5.0
 language: haskell
 author: Juan Pedro
 author-name: Juan Pedro Villa Isaza (@jpvillaisaza)


### PR DESCRIPTION
This allows to use `libraries` meta-field and then every library is rendered with its own link. I made use of `(<>)` because `mappend` is sort of too long (I don't know why Jasper keeps it in scaffold).

I also added `author-name` in tutorial template. I'm not sure why it was missing, is there any policy in place that requires Stack Builders' tutorials to be anonymous? I would be very surprised.
