### PR TITLE
Fix where the generated feeds are put

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -117,11 +117,11 @@ rules env = do
   let pumpFeedPosts =
         fmap (take 10) . recentFirst =<< loadAll "tutorials/haskell/*/*.md"
 
-  create ["atom.xml"] $ do
+  create ["tutorials/atom.xml"] $ do
     route idRoute
     compile (pumpFeedPosts >>= renderAtom feedConfiguration datedCtx)
 
-  create ["rss.xml"] $ do
+  create ["tutorials/rss.xml"] $ do
     route idRoute
     compile (pumpFeedPosts >>= renderRss feedConfiguration datedCtx)
 

--- a/templates/tutorial-list.html
+++ b/templates/tutorial-list.html
@@ -10,9 +10,9 @@
         tutorials repository on GitHub</a>.
     </p>
     <p>
-      <a href="/atom.xml" title="Atom Feed">Atom Feed</a>
+      <a href="/tutorials/atom.xml" title="Atom Feed">Atom Feed</a>
       &nbsp;
-      <a href="/rss.xml" title="RSS Feed">RSS Feed</a>
+      <a href="/tutorials/rss.xml" title="RSS Feed">RSS Feed</a>
     </p>
   </div>
   <div class="news container">


### PR DESCRIPTION
Apparently the feeds need to be placed under the `tutorials` dir to be served from the main site. My bad, of course, good that I decided to test the feeds today and noticed this.