### PR TITLE
Fix RSS and Atom including  more than once

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -132,7 +132,7 @@ feedConfiguration =
     , feedDescription = "Tutorials about tech Stack Builders consider important to promote"
     , feedAuthorName  = "Stack Builders"
     , feedAuthorEmail = "info@stackbuilders.com"
-    , feedRoot        = "https://stackbuilders.com/tutorials"
+    , feedRoot        = "https://stackbuilders.com"
     }
 
 data Hero


### PR DESCRIPTION
@mrkkrp Can you take a look?
Currently in [atom](https://stackbuilders.com/tutorials/atom.xml) and [rss](https://stackbuilders.com/tutorials/rss.xml) files we have something like:
`https://stackbuilders.com/tutorials/tutorials/haskell/generics/index.html`

With this change we fix it to:
![image](https://cloud.githubusercontent.com/assets/2164411/25819440/a2719bf4-33f3-11e7-8969-1e48810f0d62.png)
