### PR TITLE
Allow tutorials outside of `haskell`

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,6 +17,9 @@ main = getEnvironment >>= (hakyllWith configuration . rules)
 sitePort :: Int
 sitePort = 4000
 
+directories :: Pattern
+directories = "tutorials/haskell/*/*.md" .||. "tutorials/functional-full-stack/*/*.md"
+
 configuration :: Configuration
 configuration =
   defaultConfiguration
@@ -52,7 +55,7 @@ rules env = do
   create ["archive.html"] $ do
     route idRoute
     compile $ do
-      tutorials <- recentFirst =<< loadAll "tutorials/(haskell|functional-full-stack)/*/*.md"
+      tutorials <- recentFirst =<< loadAll directories
       let
         archiveContext =
           listField "tutorials" tutorialCtx (return tutorials)
@@ -68,7 +71,7 @@ rules env = do
   match "tutorials/index.html" $ do
     route idRoute
     compile $ do
-      tutorials <- recentFirst =<< loadAll "tutorials/(haskell|functional-full-stack)/*/*.md"
+      tutorials <- recentFirst =<< loadAll directories
       let
         indexContext =
           listField "tutorials" tutorialCtx (return tutorials)
@@ -87,7 +90,7 @@ rules env = do
 
   match "templates/*" (compile templateCompiler)
 
-  match "tutorials/(haskell|functional-full-stack)/*/*.md" $ do
+  match directories $ do
     let
       tutorialRoute i = takeDirectory p </> "index.html"
         where p = toFilePath i
@@ -106,7 +109,7 @@ rules env = do
   create ["tutorials/sitemap.xml"] $ do
     route   idRoute
     compile $ do
-      posts <- recentFirst =<< loadAll "tutorials/(haskell|functional-full-stack)/*/*.md"
+      posts <- recentFirst =<< loadAll directories
       let allPosts = return posts
       let sitemapCtx = listField "entries" tutorialCtx allPosts
 
@@ -115,7 +118,7 @@ rules env = do
        >>= cleanIndexHtmls
 
   let pumpFeedPosts =
-        fmap (take 10) . recentFirst =<< loadAll "tutorials/(haskell|functional-full-stack)/*/*.md"
+        fmap (take 10) . recentFirst =<< loadAll directories
 
   create ["tutorials/atom.xml"] $ do
     route idRoute

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -21,7 +21,7 @@ supportedLanguages :: [String]
 supportedLanguages = [  -- Name here the directories of the programming languages to be supported
     "haskell"
   , "functional-full-stack" -- Haskell backend + PureScript frontend
-]
+  ]
 
 directories :: Pattern
 directories = foldl (.||.) (head patterns) (tail patterns)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -52,7 +52,7 @@ rules env = do
   create ["archive.html"] $ do
     route idRoute
     compile $ do
-      tutorials <- recentFirst =<< loadAll "tutorials/haskell/*/*.md"
+      tutorials <- recentFirst =<< loadAll "tutorials/(haskell|functional-full-stack)/*/*.md"
       let
         archiveContext =
           listField "tutorials" tutorialCtx (return tutorials)
@@ -68,7 +68,7 @@ rules env = do
   match "tutorials/index.html" $ do
     route idRoute
     compile $ do
-      tutorials <- recentFirst =<< loadAll "tutorials/haskell/*/*.md"
+      tutorials <- recentFirst =<< loadAll "tutorials/(haskell|functional-full-stack)/*/*.md"
       let
         indexContext =
           listField "tutorials" tutorialCtx (return tutorials)
@@ -87,7 +87,7 @@ rules env = do
 
   match "templates/*" (compile templateCompiler)
 
-  match "tutorials/haskell/*/*.md" $ do
+  match "tutorials/(haskell|functional-full-stack)/*/*.md" $ do
     let
       tutorialRoute i = takeDirectory p </> "index.html"
         where p = toFilePath i
@@ -106,7 +106,7 @@ rules env = do
   create ["tutorials/sitemap.xml"] $ do
     route   idRoute
     compile $ do
-      posts <- recentFirst =<< loadAll "tutorials/haskell/*/*.md"
+      posts <- recentFirst =<< loadAll "tutorials/(haskell|functional-full-stack)/*/*.md"
       let allPosts = return posts
       let sitemapCtx = listField "entries" tutorialCtx allPosts
 
@@ -115,7 +115,7 @@ rules env = do
        >>= cleanIndexHtmls
 
   let pumpFeedPosts =
-        fmap (take 10) . recentFirst =<< loadAll "tutorials/haskell/*/*.md"
+        fmap (take 10) . recentFirst =<< loadAll "tutorials/(haskell|functional-full-stack)/*/*.md"
 
   create ["tutorials/atom.xml"] $ do
     route idRoute

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,8 +17,16 @@ main = getEnvironment >>= (hakyllWith configuration . rules)
 sitePort :: Int
 sitePort = 4000
 
+supportedLanguages :: [String]
+supportedLanguages = [  -- Name here the directories of the programming languages to be supported
+    "haskell"
+  , "functional-full-stack" -- Haskell backend + PureScript frontend
+]
+
 directories :: Pattern
-directories = "tutorials/haskell/*/*.md" .||. "tutorials/functional-full-stack/*/*.md"
+directories = foldl (.||.) (head patterns) (tail patterns)
+  where
+    patterns = fmap (\dir -> fromGlob $ "tutorials/" ++ dir ++ "/*/*.md") supportedLanguages
 
 configuration :: Configuration
 configuration =

--- a/tutorials/functional-full-stack/purescript-bridge/tutorial.md
+++ b/tutorials/functional-full-stack/purescript-bridge/tutorial.md
@@ -71,6 +71,7 @@ But let's not talk about limitations. Instead, let's talk about awesomeness. But
 
 ## Simple WebApp
 Our app will be split into two parts:
+
  * A Haskell backend that talks to the database, coordinates people, sends emails and all that awesome stuff backends do.
  * A PureScript frontend that compiles to JavaScript and runs on the browser;
    showing, in marvellous details using React, all the data that it fetches from the backend.
@@ -86,6 +87,7 @@ Well, it may not be the next big thing, but you will definitely need it. I promi
 
 ### Backend
 The backend is going to be simple: trusty Servant is going to provide us with endpoints that talk JSON and are full of scientist biographies. The API will provide (for now) a single endpoint:
+
 * `GET /scientist/` : return a list of scientist biographies
 
 ```haskell
@@ -267,7 +269,7 @@ All I want is to copy this backend data to the frontend, where both use an equiv
 There has to be a way to do that automatically.
 
 Well, there is a way to do that. Can you see the `Generic` instances we have introduced somehow?
-We are going to take advantage of these instances. In fact, I have not invented this - the [Argonaut](https://github.com/purescript-contrib/purescript-argonaut) folks did it!
+We are going to take advantage of these instances. In fact, I have not invented this - the [Argonaut](https://github.com/purescript-contrib/purescript-argonaut) team did it!
 They made some [Generic Argonaut-Aeson codecs](https://pursuit.purescript.org/packages/purescript-argonaut-generic-codecs/6.0.3/docs/Data.Argonaut.Generic.Aeson) which should make the frontend speak [Aeson](https://hackage.haskell.org/package/aeson) exactly the same way the backend does.
 
 The backend is already using generic encoding thanks to Template Haskell. The code that does the magic is:

--- a/tutorials/functional-full-stack/purescript-bridge/tutorial.md
+++ b/tutorials/functional-full-stack/purescript-bridge/tutorial.md
@@ -1,11 +1,11 @@
 ---
 title: Connecting a Haskell Backend to a PureScript Frontend
-published: not-yet
+published: 2017-07-17
 ghc: 7.10.3
 purs: 0.10.5
 lts: 7.17
 libraries: purescript-bridge
-language: haskell purescript
+language: functional-full-stack
 author-name: Javier Casas Velasco
 description: In this tutorial we will implement a way to extend the types in the Haskell backend to the PureScript frontend while maintaining consistency and simplifying communication.
 ---


### PR DESCRIPTION
It seems the system only allows tutorials to be placed on a `haskell` directory inside `tutorials`. Looking forward to make tutorials on other programming languages.