### PR TITLE
Add tags to the tutorials section

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -107,7 +107,7 @@ rules env = do
 
   match "templates/*" (compile templateCompiler)
 
-  tags <- buildTags markdownPattern (fromCapture "tags/*.html")
+  tags <- buildTags markdownPattern (fromCapture "tutorials/tags/*.html")
 
   tagsRules tags $ \tag pattern -> do
     let title = "Posts tagged \"" ++ tag ++ "\""

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -71,9 +71,11 @@ rules env = do
     compile $ do
       tutorials <- recentFirst =<< loadAll markdownPattern
       let
+        title = "Archives"
         archiveContext =
           listField "tutorials" tutorialCtx (return tutorials)
-            <> constField "title" "Archives"
+            <> constField "title" title
+            <> constField "title-list" title
             <> commonCtx
 
       makeItem ""
@@ -90,6 +92,7 @@ rules env = do
         indexContext =
           listField "tutorials" tutorialCtx (return tutorials)
             <> constField "title" "Home"
+            <> constField "title-list" "Tutorials"
             <> commonCtx
 
       getResourceBody
@@ -110,9 +113,10 @@ rules env = do
     let title = "Posts tagged \"" ++ tag ++ "\""
     route idRoute
     compile $ do
-      posts <- recentFirst =<< loadAll pattern
+      tutorials <- recentFirst =<< loadAll pattern
       let ctx = constField "title" title
-                `mappend` listField "tutorials" tutorialCtx (return posts)
+                `mappend` constField "title-list" title
+                `mappend` listField "tutorials" tutorialCtx (return tutorials)
                 `mappend` defaultContext
                 `mappend` commonCtx
 

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,0 +1,1 @@
+$partial("templates/tutorial-list.html")$

--- a/templates/tutorial-list.html
+++ b/templates/tutorial-list.html
@@ -15,6 +15,9 @@
       <a href="/tutorials/rss.xml" title="RSS Feed">RSS Feed</a>
     </p>
   </div>
+
+  <h1 class="title">$title-list$</h1>
+
   <div class="news container">
     $for(tutorials)$
     <div itemscope itemtype="http://schema.org/TechArticle">

--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -11,6 +11,10 @@
       $endif$
       <br/>
       by $author-name$
+      <br/>
+      $if(tags)$
+        tags: $tags$
+        $endif$
     </p>
 
     <p>

--- a/tutorials/functional-full-stack/purescript-bridge/tutorial.md
+++ b/tutorials/functional-full-stack/purescript-bridge/tutorial.md
@@ -4,7 +4,7 @@ published: 2017-07-20
 ghc: 7.10.3
 purs: 0.10.5
 lts: 7.17
-tags: purescript, haskell
+tags: purescript, haskell, web
 libraries: purescript-bridge
 language: functional-full-stack
 author-name: Javier Casas Velasco

--- a/tutorials/functional-full-stack/purescript-bridge/tutorial.md
+++ b/tutorials/functional-full-stack/purescript-bridge/tutorial.md
@@ -4,6 +4,7 @@ published: 2017-07-20
 ghc: 7.10.3
 purs: 0.10.5
 lts: 7.17
+tags: purescript, haskell
 libraries: purescript-bridge
 language: functional-full-stack
 author-name: Javier Casas Velasco

--- a/tutorials/haskell/bdd-in-haskell-with-hspec/tutorial.md
+++ b/tutorials/haskell/bdd-in-haskell-with-hspec/tutorial.md
@@ -3,7 +3,7 @@ title: Behavior-driven development (BDD) in Haskell with Hspec
 published: 2016-06-14
 ghc: 7.10.3
 lts: 5.18
-tags: haskell
+tags: haskell, bdd
 libraries: hspec-2.2.3 QuickCheck-2.8.1
 language: haskell
 author-name: Juan Carlos Pazmiño

--- a/tutorials/haskell/bdd-in-haskell-with-hspec/tutorial.md
+++ b/tutorials/haskell/bdd-in-haskell-with-hspec/tutorial.md
@@ -3,6 +3,7 @@ title: Behavior-driven development (BDD) in Haskell with Hspec
 published: 2016-06-14
 ghc: 7.10.3
 lts: 5.18
+tags: haskell
 libraries: hspec-2.2.3 QuickCheck-2.8.1
 language: haskell
 author-name: Juan Carlos Pazmiño

--- a/tutorials/haskell/bdd-in-haskell-with-hspec/tutorial.md
+++ b/tutorials/haskell/bdd-in-haskell-with-hspec/tutorial.md
@@ -3,7 +3,7 @@ title: Behavior-driven development (BDD) in Haskell with Hspec
 published: 2016-06-14
 ghc: 7.10.3
 lts: 5.18
-tags: haskell, bdd
+tags: haskell, testing
 libraries: hspec-2.2.3 QuickCheck-2.8.1
 language: haskell
 author-name: Juan Carlos Pazmiño

--- a/tutorials/haskell/csv-encoding-decoding/tutorial.md
+++ b/tutorials/haskell/csv-encoding-decoding/tutorial.md
@@ -3,6 +3,7 @@ title: CSV encoding and decoding in Haskell with Cassava
 published: 2016-05-31
 ghc: 7.10.3
 lts: 5.15
+tags: haskell
 libraries: cassava-0.4.5.0
 language: haskell
 author-name: Juan Pedro Villa Isaza

--- a/tutorials/haskell/csv-encoding-decoding/tutorial.md
+++ b/tutorials/haskell/csv-encoding-decoding/tutorial.md
@@ -3,7 +3,7 @@ title: CSV encoding and decoding in Haskell with Cassava
 published: 2016-05-31
 ghc: 7.10.3
 lts: 5.15
-tags: haskell
+tags: haskell, parsing
 libraries: cassava-0.4.5.0
 language: haskell
 author-name: Juan Pedro Villa Isaza

--- a/tutorials/haskell/generics/tutorial.md
+++ b/tutorials/haskell/generics/tutorial.md
@@ -3,6 +3,7 @@ title: GHC Generics Explained
 published: 2017-02-01
 ghc: 8.0.1
 lts: 7.16
+tags: haskell
 language: haskell
 author: Mark Karpov
 author-name: Mark Karpov

--- a/tutorials/haskell/ghc-optimization-and-fusion/tutorial.md
+++ b/tutorials/haskell/ghc-optimization-and-fusion/tutorial.md
@@ -3,6 +3,7 @@ title: GHC optimization and fusion
 published: 2016-11-29
 ghc: 8.0.1
 lts: 7.4
+tags: haskell
 libraries: criterion-1.1.1.0 weigh-0.0.3
 language: haskell
 author: Mark Karpov

--- a/tutorials/haskell/ghc-optimization-and-fusion/tutorial.md
+++ b/tutorials/haskell/ghc-optimization-and-fusion/tutorial.md
@@ -3,7 +3,7 @@ title: GHC optimization and fusion
 published: 2016-11-29
 ghc: 8.0.1
 lts: 7.4
-tags: haskell
+tags: haskell, optimization
 libraries: criterion-1.1.1.0 weigh-0.0.3
 language: haskell
 author: Mark Karpov

--- a/tutorials/haskell/gui-application/tutorial.md
+++ b/tutorials/haskell/gui-application/tutorial.md
@@ -3,6 +3,7 @@ title: Creating a GUI application in Haskell
 published: 2016-06-22
 ghc: 7.10.3
 lts: 5.18
+tags: haskell
 libraries: gtk3-0.14.4 glib-0.13.2.2
 language: haskell
 author: Mark

--- a/tutorials/haskell/gui-application/tutorial.md
+++ b/tutorials/haskell/gui-application/tutorial.md
@@ -3,7 +3,7 @@ title: Creating a GUI application in Haskell
 published: 2016-06-22
 ghc: 7.10.3
 lts: 5.18
-tags: haskell
+tags: haskell, gui
 libraries: gtk3-0.14.4 glib-0.13.2.2
 language: haskell
 author: Mark

--- a/tutorials/haskell/image-processing/tutorial.md
+++ b/tutorials/haskell/image-processing/tutorial.md
@@ -3,6 +3,7 @@ title: Image processing with Juicy Pixels and Repa
 published: 2016-06-07
 ghc: 7.10.3
 lts: 5.16
+tags: haskell
 libraries: JuicyPixels-3.2.7 repa-3.4.0.2
 language: haskell
 author: Mark

--- a/tutorials/haskell/mustache-templates/tutorial.md
+++ b/tutorials/haskell/mustache-templates/tutorial.md
@@ -2,7 +2,7 @@
 title: Mustache templates in Haskell
 published: 2016-08-17
 ghc: 8.0.1
-tags: haskell
+tags: haskell, templates
 nightly: 2016-08-15
 libraries: stache-0.1.6
 language: haskell

--- a/tutorials/haskell/mustache-templates/tutorial.md
+++ b/tutorials/haskell/mustache-templates/tutorial.md
@@ -2,6 +2,7 @@
 title: Mustache templates in Haskell
 published: 2016-08-17
 ghc: 8.0.1
+tags: haskell
 nightly: 2016-08-15
 libraries: stache-0.1.6
 language: haskell

--- a/tutorials/haskell/servant-auth/tutorial.md
+++ b/tutorials/haskell/servant-auth/tutorial.md
@@ -3,7 +3,7 @@ title: Servant authentication and sessions via cookies
 published: 2016-09-21
 ghc: 7.10.3
 lts: 6.10
-tags: haskell
+tags: haskell, web
 libraries: servant-auth-cookie-0.3.0.2 servant-0.8
 language: haskell
 author: Mark Karpov

--- a/tutorials/haskell/servant-auth/tutorial.md
+++ b/tutorials/haskell/servant-auth/tutorial.md
@@ -3,6 +3,7 @@ title: Servant authentication and sessions via cookies
 published: 2016-09-21
 ghc: 7.10.3
 lts: 6.10
+tags: haskell
 libraries: servant-auth-cookie-0.3.0.2 servant-0.8
 language: haskell
 author: Mark Karpov


### PR DESCRIPTION
### Trello Card
This Pull Request is related to this [Trello Card](https://trello.com/c/Q2lGOsPg/52-as-a-user-i-want-to-see-the-section-tags-link-in-the-blogspot-section-so-our-readers-have-option-to-read-more-articles-related)

### Screenshoots
- Tags in one blog post:
![image](https://user-images.githubusercontent.com/8370088/29845233-b06caf90-8cd7-11e7-952e-9c41aba6bc65.png)
- List
![image](https://user-images.githubusercontent.com/8370088/29847083-833cdce0-8cdf-11e7-9d96-0c1eaa8cb6c9.png)
- Route of tags
![image](https://user-images.githubusercontent.com/8370088/30032562-43a19068-915c-11e7-9e7d-061a9ef42ac3.png)


### Changes in the PR
- Tag generation under "tags/*.html"
- Add links for tags
- Add tags to blogs

@juanpaucar Could you take a look, please?
