### PR TITLE
Delete disqus section

### DIFF
--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -102,12 +102,6 @@
               <img data-no-retina="" class="img-responsive image-hover" alt="facebook-icon-hover.png" src="$host$/assets/img/facebook-icon-hover.png">
             </a>
           </div>
-          <div class="hoverable comment-share">
-            <a href="#disqus_thread">
-              <img data-no-retina="" class="img-responsive image-normal" alt="comment-icon.png" src="$host$/assets/img/comment-icon.png">
-              <img data-no-retina="" class="img-responsive image-hover" alt="comment-icon-hover.png" src="$host$/assets/img/comment-icon-hover.png">
-            </a>
-          </div>
         </div>
       </div>
     </div>
@@ -150,9 +144,6 @@
         </div>
       </div>
     </section>
-
-    <div id="disqus_thread"></div>
-    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
 
   </div>
 </div>

--- a/tutorials/javascripts/tutorials.js
+++ b/tutorials/javascripts/tutorials.js
@@ -5,18 +5,6 @@ $(document).ready(function() {
     window.open('https://www.facebook.com/sharer/sharer.php?u=' +
     $(this).attr('href'), 'Share', 'width=626,height=436');
   });
-
-  (function() {
-    var dsq       = document.createElement('script');
-        dsq.type  = 'text/javascript';
-        dsq.async = true;
-        dsq.src   = '//stackbuilders.disqus.com/embed.js';
-        dsq.setAttribute('data-timestamp', +new Date());
-
-    (document.getElementsByTagName('head')[0] ||
-        document.getElementsByTagName('body')[0]).appendChild(dsq);
-  })();
-
 });
 
 $(window).load(function() {


### PR DESCRIPTION
### Trello Card
This Pull Request is related to this [Trello Card](https://trello.com/c/abIwDE0R/170-news-delete-disqus-section)

### Screenshot
<img width="799" alt="screen shot 2018-06-13 at 4 43 35 pm" src="https://user-images.githubusercontent.com/26580546/41379944-119bab98-6f29-11e8-9673-3a93b603ad17.png">
<img width="930" alt="screen shot 2018-06-13 at 4 44 54 pm" src="https://user-images.githubusercontent.com/26580546/41379963-21715bb2-6f29-11e8-84d8-064185373d12.png">


### Changes in the PR
- Delete redirection link Disqus ( TUTORIALS )
- Delete Disqus section to comment ( TUTORIALS )
