### PR TITLE
change SITE_ROOT_URL varible

### DIFF
--- a/config/local.env
+++ b/config/local.env
@@ -1,2 +1,2 @@
-export SITE_ROOT_URL=//localhost:8080
+export SITE_ROOT_URL=//staging.stackbuilders.com
 export SITE_PROTOCOL=http:


### PR DESCRIPTION
As all static assets are loaded form stackbuilder.com repository, chaging this variable to staging allow us to work tutorials without the nescecity of having other nginx serving on another port. 