### PR TITLE
Issue #96 updated tutorials end-line

### DIFF
--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -118,7 +118,7 @@
     <p>
       Thanks for reading this tutorial! If you have any feedback, please feel free to drop us a line
       on <a href="https://twitter.com/stackbuilders">Twitter</a> or
-      <a href="https://www.facebook.com/StackBuildersEcuador/">Facebook</a> 
+      <a href="https://www.facebook.com/StackBuildersEcuador/">Facebook</a>. 
       You could also open issues and pull requests on
       <a href="https://github.com/stackbuilders/tutorials">GitHub</a>.
     </p>


### PR DESCRIPTION
Added a dot after Facebook at the end-line, related to [Card](https://github.com/stackbuilders/tutorials/issues/96)